### PR TITLE
register model name always lowercase

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ const connect = async function (server, connections) {
         }
         else if (typeof loadSchemasFrom === 'object') {
             for (const [name, schema] of Object.entries(loadSchemasFrom)) {
-                models[name] = connection.model(name, schema);
+                models[name] = connection.model(name.toLowerCase(), schema);
             }
         }
 


### PR DESCRIPTION
usually model references in schemas are lowercased, so this makes sure that the model name is always registered in lowercase.