### PR TITLE
Register schemas with lowercase `modelName` for index files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const createModel = async function (server, connection, info) {
 
     if (typeof file === 'object' &&
         file.constructor.name === 'Schema') {
-        return connection.model(info.name.toLowerCase(), file);
+        return connection.model(info.name, file);
     }
 
     throw new Error(`unable to create model for file: ${info.base}`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,16 +54,19 @@ const connect = async function (server, connections) {
             for (const info of files.map(Path.parse)) {
                 const name = Capitalize(info.name);
                 models[name] = await createModel(server, connection, info);
-                server.log(
-                    ['info', 'hapi-mongoose2'],
-                    `registered model '${name}' for database '${connection.name}'`
-                );
             }
         }
         else if (typeof loadSchemasFrom === 'object') {
             for (const [name, schema] of Object.entries(loadSchemasFrom)) {
                 models[name] = connection.model(name.toLowerCase(), schema);
             }
+        }
+
+        for (const name of Object.keys(models)) {
+            server.log(
+                ['info', 'hapi-mongoose2'],
+                `registered model '${name}' for database '${connection.name}'`
+            );
         }
 
         const mongo = { models, connection };

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ const createModel = async function (server, connection, info) {
 
     if (typeof file === 'object' &&
         file.constructor.name === 'Schema') {
-        return connection.model(info.name, file);
+        return connection.model(info.name.toLowerCase(), file);
     }
 
     throw new Error(`unable to create model for file: ${info.base}`);

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -349,6 +349,32 @@ describe('connection', () => {
         expect(models).to.only.include(['Animal', 'Person']);
     });
 
+    it('register models from package index with lowercase names', async () => {
+
+        const plugin = {
+            plugin: HapiMongoose,
+            options: {
+                connection: {
+                    uri: 'mongodb://localhost:27017/test',
+                    loadSchemasFrom: require('./schemas/package'),
+                    options
+                }
+            }
+        };
+        const server = Hapi.server();
+        await server.register(plugin);
+
+        expect(server.app).to.include('mongo');
+        expect(server.app.mongo).to.include('models');
+
+        let models = server.app.mongo.models;
+        expect(models).to.be.an.object();
+        expect(models).to.only.include(['Animal', 'Person']);
+        models = server.app.mongo.connection.models;
+        expect(models).to.be.an.object();
+        expect(models).to.only.include(['animal', 'person']);
+    });
+
     it('creates server decoration', async () => {
 
         const plugin = {


### PR DESCRIPTION
Also fixes logging model registration in all cases.